### PR TITLE
(GH-23) Fix reading of LFS tracked files

### DIFF
--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
@@ -186,7 +186,7 @@
             };
 
             settings.Arguments.Clear();
-            settings.Arguments.Add("lfs ls-files");
+            settings.Arguments.Add("lfs ls-files -n");
             var lfsTrackedFiles = this.runner.RunCommand(settings);
             if (lfsTrackedFiles == null)
             {


### PR DESCRIPTION
Fix reading of LFS tracked files by removing hash from console output.

Fixes #23 