### PR TITLE
Disable generation of documentation

### DIFF
--- a/setup.cake
+++ b/setup.cake
@@ -16,6 +16,7 @@ BuildParameters.SetParameters(
     appVeyorAccountName: "cakecontrib",
     shouldRunGitVersion: true,
     shouldRunCodecov: false,
+    shouldGenerateDocumentation: false,
     shouldRunIntegrationTests: true,
     integrationTestScriptPath: "./tests/integration/tests.cake");
 


### PR DESCRIPTION
Disable generation of documentation since this is done centrally in https://github.com/cake-contrib/Cake.Issues.Website