### PR TITLE
(GH-11) Add rule to check for files path length

### DIFF
--- a/docs/rules/FilePathTooLong.md
+++ b/docs/rules/FilePathTooLong.md
@@ -1,0 +1,24 @@
+---
+Title: FilePathTooLong
+Description: The path of a file is too long.
+---
+
+<?# Table Class=table HeaderRows=0 ?>
+<?*
+"Rule Id" FilePathTooLong
+Priority Warning
+?>
+<?#/ Table ?>
+
+## Cause
+
+The path of a file in the repository is too long.
+
+## Rule description
+
+Some operating systems and applications have a limitation of maximum path length which they can handle.
+To guarantee proper building this length should not be exceeded.
+
+## How to fix violations
+
+Rename the name of the file or shorten the path name.

--- a/src/Cake.Issues.GitRepository/BinaryFileNotTrackedByLfsRuleDescription.cs
+++ b/src/Cake.Issues.GitRepository/BinaryFileNotTrackedByLfsRuleDescription.cs
@@ -13,7 +13,7 @@
     }
 
     /// <summary>
-    /// Description of the rule which checks if the path of a binary file in the repository is too long.
+    /// Description of the rule which checks if the path of a file in the repository is too long.
     /// </summary>
     public class FilePathLengthRuleDescription : BaseGitRepositoryIssuesRuleDescription
     {

--- a/src/Cake.Issues.GitRepository/BinaryFileNotTrackedByLfsRuleDescription.cs
+++ b/src/Cake.Issues.GitRepository/BinaryFileNotTrackedByLfsRuleDescription.cs
@@ -11,16 +11,4 @@
         /// <inheritdoc />
         public override IssuePriority Priority => IssuePriority.Warning;
     }
-
-    /// <summary>
-    /// Description of the rule which checks if the path of a file in the repository is too long.
-    /// </summary>
-    public class FilePathLengthRuleDescription : BaseGitRepositoryIssuesRuleDescription
-    {
-        /// <inheritdoc />
-        public override string RuleName => "FilePathLength";
-
-        /// <inheritdoc />
-        public override IssuePriority Priority => IssuePriority.Warning;
-    }
 }

--- a/src/Cake.Issues.GitRepository/BinaryFileNotTrackedByLfsRuleDescription.cs
+++ b/src/Cake.Issues.GitRepository/BinaryFileNotTrackedByLfsRuleDescription.cs
@@ -11,4 +11,16 @@
         /// <inheritdoc />
         public override IssuePriority Priority => IssuePriority.Warning;
     }
+
+    /// <summary>
+    /// Description of the rule which checks if the path of a binary file in the repository is too long.
+    /// </summary>
+    public class BinaryFilePathLengthRuleDescription : BaseGitRepositoryIssuesRuleDescription
+    {
+        /// <inheritdoc />
+        public override string RuleName => "BinaryFilePathLength";
+
+        /// <inheritdoc />
+        public override IssuePriority Priority => IssuePriority.Warning;
+    }
 }

--- a/src/Cake.Issues.GitRepository/BinaryFileNotTrackedByLfsRuleDescription.cs
+++ b/src/Cake.Issues.GitRepository/BinaryFileNotTrackedByLfsRuleDescription.cs
@@ -15,10 +15,10 @@
     /// <summary>
     /// Description of the rule which checks if the path of a binary file in the repository is too long.
     /// </summary>
-    public class BinaryFilePathLengthRuleDescription : BaseGitRepositoryIssuesRuleDescription
+    public class FilePathLengthRuleDescription : BaseGitRepositoryIssuesRuleDescription
     {
         /// <inheritdoc />
-        public override string RuleName => "BinaryFilePathLength";
+        public override string RuleName => "FilePathLength";
 
         /// <inheritdoc />
         public override IssuePriority Priority => IssuePriority.Warning;

--- a/src/Cake.Issues.GitRepository/FilePathTooLongRuleDescription.cs
+++ b/src/Cake.Issues.GitRepository/FilePathTooLongRuleDescription.cs
@@ -1,0 +1,14 @@
+﻿namespace Cake.Issues.GitRepository
+{
+    /// <summary>
+    /// Description of the rule which checks if the path of a file in the repository is too long.
+    /// </summary>
+    public class FilePathTooLongRuleDescription : BaseGitRepositoryIssuesRuleDescription
+    {
+        /// <inheritdoc />
+        public override string RuleName => "FilePathTooLong";
+
+        /// <inheritdoc />
+        public override IssuePriority Priority => IssuePriority.Warning;
+    }
+}

--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
@@ -151,17 +151,20 @@
                 int pathLength = file.Length;
 
                 if (pathLength > length) {
-                    message = $"The path for the binary file \"{file}\", is too long";
+                    
+                    message = $"The path for the file \"{file}\", is too long";
+
+                    var ruleDescription = new FilePathLengthRuleDescription();
+
+                    result.Add(
+                        IssueBuilder
+                            .NewIssue(message, this)
+                            .InFile(file)
+                            .OfRule(ruleDescription)
+                            .Create());
+                            
                 }
 
-                var ruleDescription = new FilePathLengthRuleDescription();
-
-                result.Add(
-                    IssueBuilder
-                        .NewIssue(message, this)
-                        .InFile(file)
-                        .OfRule(ruleDescription)
-                        .Create());
             }
 
             return result;

--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
@@ -67,9 +67,9 @@
                 result.AddRange(this.CheckForBinaryFilesNotTrackedByLfs(format));
             }
 
-            if (this.IssueProviderSettings.CheckBinaryFilesPathLength)
+            if (this.IssueProviderSettings.CheckFilesPathLength)
             {
-                result.AddRange(this.CheckForBinaryFilesPathLength(this.IssueProviderSettings.BinaryFilesPathLength));
+                result.AddRange(this.CheckForFilesPathLength(this.IssueProviderSettings.FilesPathLength));
             }
 
             return result;
@@ -134,26 +134,18 @@
         /// </summary>
         /// <param name="length">Max length to be used to check the files.</param>
         /// <returns>List of issues for binary files.</returns>
-        private IEnumerable<IIssue> CheckForBinaryFilesPathLength(int length)
+        private IEnumerable<IIssue> CheckForFilesPathLength(int length)
         {
 
             IEnumerable<string> allFiles = this.GetAllFilesFromRepository();
+            List<IIssue> result = new List<IIssue>();
 
             if (!allFiles.Any())
             {
                 return new List<IIssue>();
             }
 
-            IEnumerable<string> textFiles = this.GetTextFilesFromRepository();
-            IEnumerable<string> binaryFiles = this.DetermineBinaryFiles(allFiles, textFiles);
-
-            if (!binaryFiles.Any())
-            {
-                return new List<IIssue>();
-            }
-
-            List<IIssue> result = new List<IIssue>();
-            foreach (string file in binaryFiles)
+            foreach (string file in allFiles)
             {
                 string message = null;
                 int pathLength = file.Length;
@@ -162,7 +154,7 @@
                     message = $"The path for the binary file \"{file}\", is too long";
                 }
 
-                var ruleDescription = new BinaryFilePathLengthRuleDescription();
+                var ruleDescription = new FilePathLengthRuleDescription();
 
                 result.Add(
                     IssueBuilder

--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
@@ -130,10 +130,10 @@
         }
 
          /// <summary>
-        /// Checks for binary files path length.
+        /// Checks for files path length.
         /// </summary>
         /// <param name="length">Max length to be used to check the files.</param>
-        /// <returns>List of issues for binary files.</returns>
+        /// <returns>List of issues for repository files.</returns>
         private IEnumerable<IIssue> CheckForFilesPathLength(int length)
         {
 

--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
@@ -67,6 +67,11 @@
                 result.AddRange(this.CheckForBinaryFilesNotTrackedByLfs(format));
             }
 
+            if (this.IssueProviderSettings.CheckBinaryFilesPathLength)
+            {
+                result.AddRange(this.CheckForBinaryFilesPathLength(this.IssueProviderSettings.BinaryFilesPathLength));
+            }
+
             return result;
         }
 
@@ -112,6 +117,52 @@
                 }
 
                 var ruleDescription = new BinaryFileNotTrackedByLfsRuleDescription();
+
+                result.Add(
+                    IssueBuilder
+                        .NewIssue(message, this)
+                        .InFile(file)
+                        .OfRule(ruleDescription)
+                        .Create());
+            }
+
+            return result;
+        }
+
+         /// <summary>
+        /// Checks for binary files path length.
+        /// </summary>
+        /// <param name="length">Max length to be used to check the files.</param>
+        /// <returns>List of issues for binary files.</returns>
+        private IEnumerable<IIssue> CheckForBinaryFilesPathLength(int length)
+        {
+
+            IEnumerable<string> allFiles = this.GetAllFilesFromRepository();
+
+            if (!allFiles.Any())
+            {
+                return new List<IIssue>();
+            }
+
+            IEnumerable<string> textFiles = this.GetTextFilesFromRepository();
+            IEnumerable<string> binaryFiles = this.DetermineBinaryFiles(allFiles, textFiles);
+
+            if (!binaryFiles.Any())
+            {
+                return new List<IIssue>();
+            }
+
+            List<IIssue> result = new List<IIssue>();
+            foreach (string file in binaryFiles)
+            {
+                string message = null;
+                int pathLength = file.Length;
+
+                if (pathLength > length) {
+                    message = $"The path for the binary file \"{file}\", is too long";
+                }
+
+                var ruleDescription = new BinaryFilePathLengthRuleDescription();
 
                 result.Add(
                     IssueBuilder

--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesSettings.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesSettings.cs
@@ -11,5 +11,16 @@
         /// Requires Git and Git-LFS to be available through Cake tool resolution.
         /// </summary>
         public bool CheckBinaryFilesTrackedByLfs { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the repository should be checked for
+        /// binary files path length.
+        /// </summary>
+        public bool CheckBinaryFilesPathLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the length value to be checked in the Path length check.
+        /// </summary>
+        public int BinaryFilesPathLength { get; set; }
     }
 }

--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesSettings.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesSettings.cs
@@ -14,7 +14,7 @@
 
         /// <summary>
         /// Gets or sets a value indicating whether the repository should be checked for
-        /// binary files path length.
+        /// files path length.
         /// </summary>
         public bool CheckFilesPathLength { get; set; }
 

--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesSettings.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesSettings.cs
@@ -14,13 +14,14 @@
 
         /// <summary>
         /// Gets or sets a value indicating whether the repository should be checked for
-        /// files path length.
+        /// files path longer than <see cref="MaxFilePathLength"/>.
         /// </summary>
         public bool CheckFilesPathLength { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating the length value to be checked in the Path length check.
+        /// Gets or sets a value indicating the maximum allowed length of file paths if
+        /// <see cref="CheckFilesPathLength"/> is enabled.
         /// </summary>
-        public int FilesPathLength { get; set; }
+        public int MaxFilePathLength { get; set; }
     }
 }

--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesSettings.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesSettings.cs
@@ -16,11 +16,11 @@
         /// Gets or sets a value indicating whether the repository should be checked for
         /// binary files path length.
         /// </summary>
-        public bool CheckBinaryFilesPathLength { get; set; }
+        public bool CheckFilesPathLength { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the length value to be checked in the Path length check.
         /// </summary>
-        public int BinaryFilesPathLength { get; set; }
+        public int FilesPathLength { get; set; }
     }
 }

--- a/tests/integration/tests.cake
+++ b/tests/integration/tests.cake
@@ -68,7 +68,7 @@ Task("CheckFilesPathLength")
                 new GitRepositoryIssuesSettings
                 {
                     CheckFilesPathLength = true,
-                    FilePathLength = 60
+                    FilesPathLength = 60
                 }),
             new ReadIssuesSettings(repoRootDir)
             {

--- a/tests/integration/tests.cake
+++ b/tests/integration/tests.cake
@@ -89,7 +89,8 @@ Task("CheckFilesPathLength")
 });
 
 Task("Run-All-Tests")
-    .IsDependentOn("CheckBinaryFilesTrackedByLfs", "CheckFilesPathLength");
+    .IsDependentOn("CheckBinaryFilesTrackedByLfs")
+    .IsDependentOn("CheckFilesPathLength");
 
 //////////////////////////////////////////////////
 

--- a/tests/integration/tests.cake
+++ b/tests/integration/tests.cake
@@ -78,7 +78,7 @@ Task("CheckFilesPathLength")
     var reportDir =
         repoRootDir.Combine("BuildArtifacts").Combine("TestResults").Combine("Integration");
     var reportFilePath =
-        reportDir.CombineWithFilePath("issues-report.html");
+        reportDir.CombineWithFilePath("plissues-report.html");
     EnsureDirectoryExists(reportDir);
 
     CreateIssueReport(

--- a/tests/integration/tests.cake
+++ b/tests/integration/tests.cake
@@ -46,7 +46,7 @@ Task("CheckBinaryFilesTrackedByLfs")
     var reportDir =
         repoRootDir.Combine("BuildArtifacts").Combine("TestResults").Combine("Integration");
     var reportFilePath =
-        reportDir.CombineWithFilePath("issues-report.html");
+        reportDir.CombineWithFilePath("CheckBinaryFilesTrackedByLfs.html");
     EnsureDirectoryExists(reportDir);
 
     CreateIssueReport(
@@ -68,7 +68,7 @@ Task("CheckFilesPathLength")
                 new GitRepositoryIssuesSettings
                 {
                     CheckFilesPathLength = true,
-                    FilesPathLength = 60
+                    MaxFilePathLength = 60
                 }),
             new ReadIssuesSettings(repoRootDir)
             {
@@ -78,7 +78,7 @@ Task("CheckFilesPathLength")
     var reportDir =
         repoRootDir.Combine("BuildArtifacts").Combine("TestResults").Combine("Integration");
     var reportFilePath =
-        reportDir.CombineWithFilePath("plissues-report.html");
+        reportDir.CombineWithFilePath("FilePathTooLong.html");
     EnsureDirectoryExists(reportDir);
 
     CreateIssueReport(

--- a/tests/integration/tests.cake
+++ b/tests/integration/tests.cake
@@ -56,8 +56,41 @@ Task("CheckBinaryFilesTrackedByLfs")
         reportFilePath);
 });
 
+Task("CheckFilesPathLength")
+    .Does(() =>
+{
+    var repoRootDir = MakeAbsolute(Directory("../../"));
+
+    var issues =
+        ReadIssues(
+            GitRepositoryIssuesAliases.GitRepositoryIssues(
+                Context,
+                new GitRepositoryIssuesSettings
+                {
+                    CheckFilesPathLength = true,
+                    FilePathLength = 60
+                }),
+            new ReadIssuesSettings(repoRootDir)
+            {
+                 Format = IssueCommentFormat.Html
+            });
+
+    var reportDir =
+        repoRootDir.Combine("BuildArtifacts").Combine("TestResults").Combine("Integration");
+    var reportFilePath =
+        reportDir.CombineWithFilePath("issues-report.html");
+    EnsureDirectoryExists(reportDir);
+
+    CreateIssueReport(
+        issues,
+        GenericIssueReportFormatFromEmbeddedTemplate(GenericIssueReportTemplate.HtmlDiagnostic),
+        repoRootDir,
+        reportFilePath);
+});
+
 Task("Run-All-Tests")
-    .IsDependentOn("CheckBinaryFilesTrackedByLfs");
+    .IsDependentOn("CheckBinaryFilesTrackedByLfs")
+    .IsDependentOn("CheckFilesPathLength");
 
 //////////////////////////////////////////////////
 

--- a/tests/integration/tests.cake
+++ b/tests/integration/tests.cake
@@ -89,8 +89,7 @@ Task("CheckFilesPathLength")
 });
 
 Task("Run-All-Tests")
-    .IsDependentOn("CheckBinaryFilesTrackedByLfs")
-    .IsDependentOn("CheckFilesPathLength");
+    .IsDependentOn("CheckBinaryFilesTrackedByLfs", "CheckFilesPathLength");
 
 //////////////////////////////////////////////////
 


### PR DESCRIPTION
Created new variables for GetRepositoryIssuesSettings class, new class BinaryFilePathLengthRuleDescription and new method in GetRepositoryProvider to check for files path length.

I believe this will help you.

Fixes #11 