### PR TITLE
(GH-120) Treat exit code '1' as successful

### DIFF
--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
@@ -199,6 +199,9 @@
             var settings = new GitRunnerSettings
             {
                 WorkingDirectory = this.Settings.RepositoryRoot,
+
+                // git grep -IL . can return an exit code of 1 if nothing matches
+                HandleExitCode = exitCode => (exitCode == 0 || exitCode == 1),
             };
 
             settings.Arguments.Clear();


### PR DESCRIPTION
Fixes #120.

Perhaps, a better fix would be to add a proper lambda to the `HandleExitCode` property of the `ToolSettings` class, like this one:

```
var settings = new GitRunnerSettings
{
    WorkingDirectory = this.Settings.RepositoryRoot,
    HandleExitCode = exitCode => (exitCode == 0 || exitCode == 1) ? true : false,
};
```

However, this is a new API introduced after the version of cake the addin is built with (0.32.1).
I should also say that I failed to reproduce the error. For me, it always returned an empty report, even for a clean repo just created with `git init`. Anyway, this fix should add extra confidence.
