### PR TITLE
(GH-125) Multi-Target .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

### DIFF
--- a/nuspec/nuget/Cake.Issues.GitRepository.nuspec
+++ b/nuspec/nuget/Cake.Issues.GitRepository.nuspec
@@ -28,8 +28,14 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0/Cake.Issues.GitRepository.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Cake.Issues.GitRepository.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0/Cake.Issues.GitRepository.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1/Cake.Issues.GitRepository.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Cake.Issues.GitRepository.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1/Cake.Issues.GitRepository.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0/Cake.Issues.GitRepository.dll" target="lib\net5.0" />
+    <file src="net5.0/Cake.Issues.GitRepository.pdb" target="lib\net5.0" />
+    <file src="net5.0/Cake.Issues.GitRepository.xml" target="lib\net5.0" />
+    <file src="net6.0/Cake.Issues.GitRepository.dll" target="lib\net6.0" />
+    <file src="net6.0/Cake.Issues.GitRepository.pdb" target="lib\net6.0" />
+    <file src="net6.0/Cake.Issues.GitRepository.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
+++ b/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Description>Tests for the Cake.Issues.GitRepository addin</Description>
     <Authors>Pascal Berger</Authors>

--- a/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
+++ b/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Git repository linting support for the Cake.Issues addin for Cake Build Automation System</Description>
     <Authors>Pascal Berger</Authors>
     <Product>Cake.Issues</Product>


### PR DESCRIPTION
Multi-Target .NET Core 3.1, 5, & 6 to follow best-practices for Cake 2.0.

Fixes #125