### PR TITLE
(GH-161) Build against Cake 3.0 and update target frameworks

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,12 +4,21 @@
 image: Visual Studio 2022
 
 #---------------------------------#
-#  Build Script                   #
+#  Install .NET                   #
 #---------------------------------#
 install:
-  # Update to latest NuGet version since we require 5.3.0 for embedded icon
-  - ps: nuget update -self
+  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
+  - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
+  - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 5.0.408 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.405 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 7.0.102 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+  - ps: dotnet --info
 
+#---------------------------------#
+#  Build Script                   #
+#---------------------------------#
 build_script:
   - ps: .\build.ps1 --target=CI
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,19 @@ jobs:
   pool:
     vmImage: 'windows-2022'
   steps:
+  # .NET 5 required for GitVersion
+  - task: UseDotNet@2
+    inputs:
+      version: '5.x'
+    displayName: 'Install .NET 5'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
+  - task: UseDotNet@2
+    inputs:
+      version: '7.x'
+    displayName: 'Install .NET 7'
   - powershell: ./build.ps1
     displayName: 'Build'
   - publish: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
@@ -30,6 +43,10 @@ jobs:
   - download: current
     artifact: NuGet Package
     displayName: 'Download build artifact'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: CopyFiles@2
     inputs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
@@ -51,6 +68,10 @@ jobs:
   - download: current
     artifact: NuGet Package
     displayName: 'Download build artifact'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: CopyFiles@2
     inputs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
@@ -72,6 +93,10 @@ jobs:
   - download: current
     artifact: NuGet Package
     displayName: 'Download build artifact'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: CopyFiles@2
     inputs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
@@ -93,6 +118,10 @@ jobs:
   - download: current
     artifact: NuGet Package
     displayName: 'Download build artifact'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: CopyFiles@2
     inputs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
@@ -114,6 +143,10 @@ jobs:
   - download: current
     artifact: NuGet Package
     displayName: 'Download build artifact'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: CopyFiles@2
     inputs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
@@ -135,6 +168,10 @@ jobs:
   - download: current
     artifact: NuGet Package
     displayName: 'Download build artifact'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: CopyFiles@2
     inputs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package

--- a/nuspec/nuget/Cake.Issues.GitRepository.nuspec
+++ b/nuspec/nuget/Cake.Issues.GitRepository.nuspec
@@ -28,14 +28,11 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netcoreapp3.1/Cake.Issues.GitRepository.dll" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1/Cake.Issues.GitRepository.pdb" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1/Cake.Issues.GitRepository.xml" target="lib\netcoreapp3.1" />
-    <file src="net5.0/Cake.Issues.GitRepository.dll" target="lib\net5.0" />
-    <file src="net5.0/Cake.Issues.GitRepository.pdb" target="lib\net5.0" />
-    <file src="net5.0/Cake.Issues.GitRepository.xml" target="lib\net5.0" />
     <file src="net6.0/Cake.Issues.GitRepository.dll" target="lib\net6.0" />
     <file src="net6.0/Cake.Issues.GitRepository.pdb" target="lib\net6.0" />
     <file src="net6.0/Cake.Issues.GitRepository.xml" target="lib\net6.0" />
+    <file src="net7.0/Cake.Issues.GitRepository.dll" target="lib\net7.0" />
+    <file src="net7.0/Cake.Issues.GitRepository.pdb" target="lib\net7.0" />
+    <file src="net7.0/Cake.Issues.GitRepository.xml" target="lib\net7.0" />
   </files>
 </package>

--- a/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
+++ b/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Description>Tests for the Cake.Issues.GitRepository addin</Description>
     <Authors>Pascal Berger</Authors>

--- a/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
+++ b/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
@@ -29,7 +29,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="Cake.Testing">
-      <Version>2.0.0</Version>
+      <Version>3.0.0</Version>
     </PackageReference>
     <PackageReference Include="Shouldly">
       <Version>4.1.0</Version>

--- a/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
+++ b/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Cake.Issues">
-      <Version>2.0.0</Version>
+      <Version>3.0.0-beta0002</Version>
     </PackageReference>
     <PackageReference Include="Cake.Issues.Testing">
-      <Version>2.0.0</Version>
+      <Version>3.0.0-beta0002</Version>
     </PackageReference>
     <PackageReference Include="Cake.Testing">
       <Version>3.0.0</Version>

--- a/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
+++ b/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
@@ -31,7 +31,7 @@
       <Version>3.0.0</Version>
     </PackageReference>
     <PackageReference Include="Cake.Issues">
-      <Version>2.0.0</Version>
+      <Version>3.0.0-beta0002</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
+++ b/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cake.Core">
-      <Version>2.0.0</Version>
+      <Version>3.0.0</Version>
     </PackageReference>
     <PackageReference Include="Cake.Issues">
       <Version>2.0.0</Version>

--- a/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
+++ b/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Description>Git repository linting support for the Cake.Issues addin for Cake Build Automation System</Description>
     <Authors>Pascal Berger</Authors>
     <Product>Cake.Issues</Product>

--- a/tests/script-runner/.config/dotnet-tools.json
+++ b/tests/script-runner/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
       "cake.tool": {
-        "version": "2.0.0",
+        "version": "3.0.0",
         "commands": [
           "dotnet-cake"
         ]


### PR DESCRIPTION
Build against Cake 3.0, Cake Issues 3.0 Beta 2 and updates target frameworks to .NET 6 and .NET 7.

Fixes #161
Fixes #162
Fixes #163 